### PR TITLE
Add save-photo node and Compute Kit examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,23 @@ docker run -it -p 1880:1880 -v ${PWD}/flows:/data -v ${PWD}:/node-red-dexi --nam
 docker exec -it dexi-node-red /bin/bash
 ```
 
-4. Install the nodes for local development since we already mapped the host folder node-red-dexi to the container folder /node-red-dexi
+4. First, install the package dependencies in the mapped directory
 ```
+cd /node-red-dexi
+npm install
+```
+
+5. Install the nodes for local development since we already mapped the host folder node-red-dexi to the container folder /node-red-dexi
+```
+cd /usr/src/node-red
 npm install /node-red-dexi
 ```
 
-5. Install other nodes
+6. Install other nodes
 
 ```
 npm install node-red-contrib-ui-led
 npm install node-red-node-ui-iframe
 ```
 
-6. Stop and start container to pick up changes.
+7. Stop and start container to pick up changes.

--- a/flows/flows.json
+++ b/flows/flows.json
@@ -88,6 +88,30 @@
         "env": []
     },
     {
+        "id": "0ec8cb42ee99a00d",
+        "type": "tab",
+        "label": "Compute Kit Servo Control",
+        "disabled": true,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "142bd2ed15f43c13",
+        "type": "tab",
+        "label": "Compute Kit GPIO",
+        "disabled": true,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "e9b2c26d123cc246",
+        "type": "tab",
+        "label": "Compute Kit Open Collector (Laser Pulse)",
+        "disabled": true,
+        "info": "",
+        "env": []
+    },
+    {
         "id": "27129f80a96ce509",
         "type": "ros2-websocket-server",
         "url": "ws://192.168.4.1:9090"
@@ -348,6 +372,36 @@
         "width": 6,
         "collapse": false,
         "className": ""
+    },
+    {
+        "id": "6a7e8942e68a5c2e",
+        "type": "ui_tab",
+        "name": "Compute Kit",
+        "icon": "dashboard",
+        "order": 4,
+        "disabled": false,
+        "hidden": false
+    },
+    {
+        "id": "c6e2654e4bd7b809",
+        "type": "ui_group",
+        "name": "Main",
+        "tab": "6a7e8942e68a5c2e",
+        "order": 1,
+        "disp": true,
+        "width": 6,
+        "collapse": false,
+        "className": ""
+    },
+    {
+        "id": "45b05d4941beab87",
+        "type": "ui_spacer",
+        "z": "142bd2ed15f43c13",
+        "name": "spacer",
+        "group": "c6e2654e4bd7b809",
+        "order": 4,
+        "width": 1,
+        "height": 1
     },
     {
         "id": "dc3e05c5e05fe586",
@@ -5058,6 +5112,483 @@
         "outputs": 0,
         "x": 660,
         "y": 100,
+        "wires": []
+    },
+    {
+        "id": "9c4db8541a85f472",
+        "type": "servo",
+        "z": "0ec8cb42ee99a00d",
+        "name": "servo 0 (0 degrees)",
+        "servoId": "0",
+        "angle": "0",
+        "x": 350,
+        "y": 180,
+        "wires": [
+            [
+                "587a4e5953b42928"
+            ]
+        ]
+    },
+    {
+        "id": "587a4e5953b42928",
+        "type": "ros2-service-call",
+        "z": "0ec8cb42ee99a00d",
+        "server": "27129f80a96ce509",
+        "x": 680,
+        "y": 240,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "24ceaa76f5bab1b7",
+        "type": "ui_button",
+        "z": "0ec8cb42ee99a00d",
+        "name": "",
+        "group": "c6e2654e4bd7b809",
+        "order": 1,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "label": "Servo 0 Open",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 160,
+        "y": 180,
+        "wires": [
+            [
+                "9c4db8541a85f472"
+            ]
+        ]
+    },
+    {
+        "id": "70964a0e08a70969",
+        "type": "servo",
+        "z": "0ec8cb42ee99a00d",
+        "name": "servo 0 (180 degrees)",
+        "servoId": "0",
+        "angle": "180",
+        "x": 360,
+        "y": 240,
+        "wires": [
+            [
+                "587a4e5953b42928"
+            ]
+        ]
+    },
+    {
+        "id": "d0a830d2a97d63fa",
+        "type": "ui_button",
+        "z": "0ec8cb42ee99a00d",
+        "name": "",
+        "group": "c6e2654e4bd7b809",
+        "order": 2,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "label": "Servo 0 Close",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 160,
+        "y": 240,
+        "wires": [
+            [
+                "70964a0e08a70969"
+            ]
+        ]
+    },
+    {
+        "id": "0273ae2d0a88cf4a",
+        "type": "servo",
+        "z": "0ec8cb42ee99a00d",
+        "name": "servo 1",
+        "servoId": "1",
+        "angle": "90",
+        "x": 320,
+        "y": 300,
+        "wires": [
+            [
+                "587a4e5953b42928"
+            ]
+        ]
+    },
+    {
+        "id": "5b2bdcec3ceb2183",
+        "type": "ui_slider",
+        "z": "0ec8cb42ee99a00d",
+        "name": "",
+        "label": "Servo 1 Slider",
+        "tooltip": "",
+        "group": "c6e2654e4bd7b809",
+        "order": 3,
+        "width": 0,
+        "height": 0,
+        "passthru": true,
+        "outs": "all",
+        "topic": "topic",
+        "topicType": "msg",
+        "min": 0,
+        "max": "180",
+        "step": 1,
+        "className": "",
+        "x": 160,
+        "y": 300,
+        "wires": [
+            [
+                "0273ae2d0a88cf4a"
+            ]
+        ]
+    },
+    {
+        "id": "e3bbbded576d22b0",
+        "type": "comment",
+        "z": "0ec8cb42ee99a00d",
+        "name": "Attach two servos to compute kit ports 0 and 1",
+        "info": "",
+        "x": 260,
+        "y": 100,
+        "wires": []
+    },
+    {
+        "id": "d709c92d023be2d0",
+        "type": "write-gpio",
+        "z": "142bd2ed15f43c13",
+        "name": "Pin 0 high",
+        "boardtype": "computekit",
+        "pinnumber": "0",
+        "pinstate": "true",
+        "stampheader": false,
+        "x": 320,
+        "y": 220,
+        "wires": [
+            [
+                "69867ae2360210c3"
+            ]
+        ]
+    },
+    {
+        "id": "90ae78b5e6f667f4",
+        "type": "inject",
+        "z": "142bd2ed15f43c13",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 120,
+        "y": 220,
+        "wires": [
+            [
+                "d709c92d023be2d0"
+            ]
+        ]
+    },
+    {
+        "id": "69867ae2360210c3",
+        "type": "ros2-service-call",
+        "z": "142bd2ed15f43c13",
+        "server": "27129f80a96ce509",
+        "x": 520,
+        "y": 240,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "9be6d9f1768a2010",
+        "type": "write-gpio",
+        "z": "142bd2ed15f43c13",
+        "name": "Pin 0 low",
+        "boardtype": "computekit",
+        "pinnumber": "0",
+        "pinstate": "false",
+        "stampheader": false,
+        "x": 320,
+        "y": 280,
+        "wires": [
+            [
+                "69867ae2360210c3"
+            ]
+        ]
+    },
+    {
+        "id": "144fb41742ad6623",
+        "type": "inject",
+        "z": "142bd2ed15f43c13",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 120,
+        "y": 280,
+        "wires": [
+            [
+                "9be6d9f1768a2010"
+            ]
+        ]
+    },
+    {
+        "id": "f61df10b0d51e8d6",
+        "type": "ui_button",
+        "z": "142bd2ed15f43c13",
+        "name": "",
+        "group": "c6e2654e4bd7b809",
+        "order": 4,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "label": "GPIO 0 High",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 130,
+        "y": 160,
+        "wires": [
+            [
+                "d709c92d023be2d0"
+            ]
+        ]
+    },
+    {
+        "id": "36364799fa60f92b",
+        "type": "ui_button",
+        "z": "142bd2ed15f43c13",
+        "name": "",
+        "group": "c6e2654e4bd7b809",
+        "order": 5,
+        "width": 0,
+        "height": 0,
+        "passthru": false,
+        "label": "GPIO 0 Low",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "",
+        "payloadType": "str",
+        "topic": "topic",
+        "topicType": "msg",
+        "x": 130,
+        "y": 340,
+        "wires": [
+            [
+                "9be6d9f1768a2010"
+            ]
+        ]
+    },
+    {
+        "id": "c29980b232b731fc",
+        "type": "comment",
+        "z": "142bd2ed15f43c13",
+        "name": "Attach LED circuit to GPIO port 0",
+        "info": "",
+        "x": 170,
+        "y": 100,
+        "wires": []
+    },
+    {
+        "id": "3e8c68b2c73ac60c",
+        "type": "write-gpio",
+        "z": "e9b2c26d123cc246",
+        "name": "Laser On",
+        "boardtype": "computekit",
+        "pinnumber": "15",
+        "pinstate": "true",
+        "stampheader": false,
+        "x": 200,
+        "y": 220,
+        "wires": [
+            [
+                "1d2bbddafb31dbc5"
+            ]
+        ]
+    },
+    {
+        "id": "88ba407c025fb4ec",
+        "type": "inject",
+        "z": "e9b2c26d123cc246",
+        "name": "Start Laser Loop",
+        "props": [
+            {
+                "p": "payload"
+            },
+            {
+                "p": "topic",
+                "vt": "str"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 200,
+        "y": 140,
+        "wires": [
+            [
+                "3e8c68b2c73ac60c"
+            ]
+        ]
+    },
+    {
+        "id": "1d2bbddafb31dbc5",
+        "type": "ros2-service-call",
+        "z": "e9b2c26d123cc246",
+        "server": "27129f80a96ce509",
+        "x": 380,
+        "y": 220,
+        "wires": [
+            [
+                "bbe56520b9ed6ec8"
+            ]
+        ]
+    },
+    {
+        "id": "bbe56520b9ed6ec8",
+        "type": "delay",
+        "z": "e9b2c26d123cc246",
+        "name": "",
+        "pauseType": "delay",
+        "timeout": "250",
+        "timeoutUnits": "milliseconds",
+        "rate": "1",
+        "nbRateUnits": "1",
+        "rateUnits": "second",
+        "randomFirst": "1",
+        "randomLast": "5",
+        "randomUnits": "seconds",
+        "drop": false,
+        "allowrate": false,
+        "outputs": 1,
+        "x": 570,
+        "y": 220,
+        "wires": [
+            [
+                "6d54454c7d0bd609"
+            ]
+        ]
+    },
+    {
+        "id": "6d54454c7d0bd609",
+        "type": "write-gpio",
+        "z": "e9b2c26d123cc246",
+        "name": "Laser Off",
+        "boardtype": "computekit",
+        "pinnumber": "15",
+        "pinstate": "false",
+        "stampheader": false,
+        "x": 200,
+        "y": 320,
+        "wires": [
+            [
+                "37899b58d7c98705"
+            ]
+        ]
+    },
+    {
+        "id": "37899b58d7c98705",
+        "type": "ros2-service-call",
+        "z": "e9b2c26d123cc246",
+        "server": "27129f80a96ce509",
+        "x": 380,
+        "y": 320,
+        "wires": [
+            [
+                "4e5e0aa1f410873f"
+            ]
+        ]
+    },
+    {
+        "id": "4e5e0aa1f410873f",
+        "type": "delay",
+        "z": "e9b2c26d123cc246",
+        "name": "",
+        "pauseType": "delay",
+        "timeout": "250",
+        "timeoutUnits": "milliseconds",
+        "rate": "1",
+        "nbRateUnits": "1",
+        "rateUnits": "second",
+        "randomFirst": "1",
+        "randomLast": "5",
+        "randomUnits": "seconds",
+        "drop": false,
+        "allowrate": false,
+        "outputs": 1,
+        "x": 570,
+        "y": 320,
+        "wires": [
+            [
+                "3e8c68b2c73ac60c"
+            ]
+        ]
+    },
+    {
+        "id": "e9a77ec95437c2a1",
+        "type": "comment",
+        "z": "e9b2c26d123cc246",
+        "name": "This assumes a KY-008 laser wired to the compute kit pin 15",
+        "info": "",
+        "x": 320,
+        "y": 40,
+        "wires": []
+    },
+    {
+        "id": "ef4a4581ceb96f02",
+        "type": "comment",
+        "z": "e9b2c26d123cc246",
+        "name": "KY-008 signal pin to 5V on compute kit, KY-008 negative pin to OC on compute kit",
+        "info": "",
+        "x": 390,
+        "y": 80,
         "wires": []
     }
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@droneblocks/node-red-dexi",
-  "version": "0.0.10",
+  "version": "0.0.12",
   "node-red": {
     "nodes": {
       "offboard": "src/offboard.js",
@@ -19,6 +19,7 @@
       "led": "src/led.js",
       "led-pixel": "src/led-pixel.js",
       "led-effect": "src/led-effect.js",
+      "servo": "src/servo.js",
       "ros2-websocket-server": "src/ros2-websocket-server.js",
       "ros2-subscribe": "src/ros2-subscribe.js",
       "ros2-publish": "src/ros2-publish.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@droneblocks/node-red-dexi",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "node-red": {
     "nodes": {
       "offboard": "src/offboard.js",

--- a/package.json
+++ b/package.json
@@ -20,14 +20,12 @@
       "led-pixel": "src/led-pixel.js",
       "led-effect": "src/led-effect.js",
       "ros2-websocket-server": "src/ros2-websocket-server.js",
-      "ros2-subsribe": "src/ros2-subscribe.js",
+      "ros2-subscribe": "src/ros2-subscribe.js",
       "ros2-publish": "src/ros2-publish.js",
       "ros2-service-call": "src/ros2-service-call.js",
       "write-gpio": "src/write-gpio.js",
       "image-preview": "src/image-preview.js",
-      "save-photo": "src/save-photo.js",
-      "coco-ssd": "src/coco-ssd.js",
-      "hand-pose": "src/hand-pose.js"
+      "save-photo": "src/save-photo.js"
     }
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
       "ros2-service-call": "src/ros2-service-call.js",
       "write-gpio": "src/write-gpio.js",
       "image-preview": "src/image-preview.js",
+      "save-photo": "src/save-photo.js",
       "coco-ssd": "src/coco-ssd.js",
       "hand-pose": "src/hand-pose.js"
     }

--- a/src/save-photo.html
+++ b/src/save-photo.html
@@ -1,13 +1,11 @@
 <script type="text/javascript">
     (function() {
-        const DEFAULT_IMAGE_WIDTH = 160
+        const DEFAULT_IMAGE_WIDTH = 320
         RED.nodes.registerType('save-photo', {
             category: 'DEXI',
             color: '#88A882',
             defaults: {
                 name: { value: "" },
-                topicType: { value: "compressed" },
-                topicName: { value: "/cam0/image_raw/compressed" },
                 width: {
                     value: DEFAULT_IMAGE_WIDTH,
                     required: true,
@@ -28,9 +26,7 @@
             labelStyle: function () {
                 return this.name ? "node_label_italic" : "";
             },
-            inputLabels: function () {
-                return this.topicName;
-            },
+            inputLabels: "image data",
             button: {
                 enabled: function() { return !this.autoSave; },
                 visible: function() { return !this.autoSave; },
@@ -47,29 +43,6 @@
             },
             oneditprepare: function () {
                 $('#node-input-width').val(this.width || DEFAULT_IMAGE_WIDTH);
-
-                // Set up topic type dropdown and update topic name accordingly
-                const updateTopicName = function() {
-                    const topicType = $('#node-input-topicType').val();
-                    let topicName;
-                    switch(topicType) {
-                        case 'raw':
-                            topicName = '/cam0/image_raw';
-                            break;
-                        case 'compressed':
-                            topicName = '/cam0/image_raw/compressed';
-                            break;
-                        case 'compressed_2hz':
-                            topicName = '/cam0/image_raw/compressed_2hz';
-                            break;
-                        default:
-                            topicName = '/cam0/image_raw/compressed';
-                    }
-                    $('#node-input-topicName').val(topicName);
-                };
-
-                $('#node-input-topicType').change(updateTopicName);
-                updateTopicName(); // Set initial value
             }
         });
 
@@ -218,18 +191,6 @@
 
     <script type="text/html" data-template-name="save-photo">
         <div class="form-row">
-            <label for="node-input-topicType"><i class="fa fa-video-camera"></i> Image Type</label>
-            <select id="node-input-topicType" style="width:70%">
-                <option value="raw">Raw (uncompressed)</option>
-                <option value="compressed">Compressed (full rate)</option>
-                <option value="compressed_2hz">Compressed (2 fps)</option>
-            </select>
-        </div>
-        <div class="form-row">
-            <label for="node-input-topicName"><i class="fa fa-tag"></i> Topic</label>
-            <input type="text" id="node-input-topicName" readonly style="width:70%; background-color: #f0f0f0;">
-        </div>
-        <div class="form-row">
             <label for="node-input-width"><i class="fa fa-arrows-h"></i> Width</label>
             <input type="number" id="node-input-width">
         </div>
@@ -254,15 +215,10 @@
     </script>
 
     <script type="text/html" data-help-name="save-photo">
-        <p>Save photo node that subscribes to camera topics and saves JPG images directly to your computer via browser downloads.</p>
-        <p><strong>Image Types:</strong>
-        <ul>
-            <li><strong>Raw:</strong> Uncompressed images from /cam0/image_raw (higher bandwidth)</li>
-            <li><strong>Compressed:</strong> JPEG compressed images from /cam0/image_raw/compressed (recommended)</li>
-            <li><strong>Compressed (2 fps):</strong> Throttled JPEG images at 2fps from /cam0/image_raw/compressed_2hz</li>
-        </ul>
-        </p>
+        <p>Save photo node that accepts image data from input messages and saves JPG images directly to your computer via browser downloads.</p>
+        <p><strong>Input:</strong> Expects image data in the input message payload. Supports base64-encoded images or ROS image message formats.</p>
         <p><strong>Auto-save:</strong> When enabled, images are automatically downloaded when received.</p>
         <p><strong>Manual save:</strong> When auto-save is disabled, click the node button or the download icon on the image to save.</p>
+        <p><strong>Usage:</strong> Connect a ros2-subscribe node or other image source to provide image data to this node.</p>
         <p><strong>Note:</strong> All images are saved as JPG format with timestamp in filename.</p>
     </script>

--- a/src/save-photo.html
+++ b/src/save-photo.html
@@ -1,0 +1,268 @@
+<script type="text/javascript">
+    (function() {
+        const DEFAULT_IMAGE_WIDTH = 160
+        RED.nodes.registerType('save-photo', {
+            category: 'DEXI',
+            color: '#88A882',
+            defaults: {
+                name: { value: "" },
+                topicType: { value: "compressed" },
+                topicName: { value: "/cam0/image_raw/compressed" },
+                width: {
+                    value: DEFAULT_IMAGE_WIDTH,
+                    required: true,
+                    validate: function (v) { return !v || !isNaN(parseInt(v, 10)) }
+                },
+                filename: { value: "dexi_photo" },
+                autoSave: { value: false },
+                showPreview: { value: true }
+            },
+            inputs: 1,
+            outputs: 1,
+            icon: "font-awesome/fa-camera",
+            align: 'right',
+            palettelabel: "save photo",
+            label: function () {
+                return this.name || "save photo";
+            },
+            labelStyle: function () {
+                return this.name ? "node_label_italic" : "";
+            },
+            inputLabels: function () {
+                return this.topicName;
+            },
+            button: {
+                enabled: function() { return !this.autoSave; },
+                visible: function() { return !this.autoSave; },
+                onclick: function () {
+                    const nodeId = this.id;
+                    const latestImage = latestImages[nodeId];
+                    if (latestImage) {
+                        downloadImage(latestImage, this.filename, 'jpg');
+                        RED.notify("Image downloaded", "success");
+                    } else {
+                        RED.notify("No image available to download", "warning");
+                    }
+                }
+            },
+            oneditprepare: function () {
+                $('#node-input-width').val(this.width || DEFAULT_IMAGE_WIDTH);
+
+                // Set up topic type dropdown and update topic name accordingly
+                const updateTopicName = function() {
+                    const topicType = $('#node-input-topicType').val();
+                    let topicName;
+                    switch(topicType) {
+                        case 'raw':
+                            topicName = '/cam0/image_raw';
+                            break;
+                        case 'compressed':
+                            topicName = '/cam0/image_raw/compressed';
+                            break;
+                        case 'compressed_2hz':
+                            topicName = '/cam0/image_raw/compressed_2hz';
+                            break;
+                        default:
+                            topicName = '/cam0/image_raw/compressed';
+                    }
+                    $('#node-input-topicName').val(topicName);
+                };
+
+                $('#node-input-topicType').change(updateTopicName);
+                updateTopicName(); // Set initial value
+            }
+        });
+
+        const latestImages = {}
+
+        function downloadImage(imageData, filename) {
+            const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+            const fullFilename = `${filename}_${timestamp}.jpg`;
+
+            let dataUrl;
+            if (imageData.startsWith("data:")) {
+                dataUrl = imageData;
+            } else if (imageData.startsWith("http")) {
+                // For URLs, we'd need to fetch and convert - for now just open in new tab
+                window.open(imageData, '_blank');
+                return;
+            } else {
+                // Assume base64 JPEG from compressed topic
+                dataUrl = `data:image/jpeg;base64,${imageData}`;
+            }
+
+            // Create download link
+            const link = document.createElement('a');
+            link.href = dataUrl;
+            link.download = fullFilename;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        }
+
+        var remove = function(nodeid) {
+            const id = nodeid
+            const $img = document.getElementById("save-photo-img-" + id)
+            const $bubble = document.getElementById("save-photo-bubble-" + id)
+            const $button = document.getElementById("save-photo-btn-" + id)
+
+            $img && $img.remove()
+            $bubble && $bubble.remove()
+            $button && $button.remove()
+            delete latestImages[id]
+        }
+
+        var redraw = function(node) {
+            const id = node.id
+            remove(id)
+            if (latestImages[id] && node.showPreview) {
+                render(id, latestImages[id], node)
+            }
+        }
+
+        var render = function(id, data, node) {
+            if (!node.showPreview) return;
+
+            let i = new Image();
+            let $img = document.getElementById("camera-capture-img-" + id)
+            if (!$img) {
+                const $container = document.getElementById(id)
+                if (!$container) { return }
+
+                const bubble = document.createElementNS("http://www.w3.org/2000/svg", 'polyline')
+                bubble.setAttribute('id', "save-photo-bubble-" + id)
+                bubble.setAttribute('style', 'fill:#E8F0E8')
+                bubble.setAttribute('stroke', '#999999')
+                $container.insertBefore(bubble, $container.lastChild.nextSibling)
+
+                const img = document.createElementNS("http://www.w3.org/2000/svg", 'image')
+                img.setAttribute('id', "save-photo-img-" + id)
+                img.setAttribute('x', '0')
+                img.setAttribute('y', '45')
+                img.setAttribute('width', node.width || DEFAULT_IMAGE_WIDTH)
+                $container.insertBefore(img, $container.lastChild.nextSibling)
+
+                // Add download button overlay
+                if (!node.autoSave) {
+                    const downloadBtn = document.createElementNS("http://www.w3.org/2000/svg", 'text')
+                    downloadBtn.setAttribute('id', "save-photo-btn-" + id)
+                    downloadBtn.setAttribute('x', '5')
+                    downloadBtn.setAttribute('y', '60')
+                    downloadBtn.setAttribute('fill', 'white')
+                    downloadBtn.setAttribute('font-size', '12')
+                    downloadBtn.setAttribute('cursor', 'pointer')
+                    downloadBtn.textContent = '📥'
+                    downloadBtn.addEventListener("click", function() {
+                        downloadImage(latestImages[id], node.filename);
+                    })
+                    $container.insertBefore(downloadBtn, $container.lastChild.nextSibling)
+                }
+
+                $img = img
+            }
+
+            i.onload = function () {
+                $img.setAttribute('height', node.width * i.height / i.width)
+                const bubbleId = $img.id.replace("img", "bubble");
+                const $bubble = document.getElementById(bubbleId)
+                let imgBbox = {}
+                imgBbox.x = 0;
+                imgBbox.y = 45;
+                imgBbox.width = node.width || DEFAULT_IMAGE_WIDTH;
+                imgBbox.height = parseInt(node.width * i.height / i.width);
+                const left = imgBbox.x
+                const top = imgBbox.y + 2
+                const right = imgBbox.x + imgBbox.width
+                const bottom = imgBbox.y + imgBbox.height
+                const points =
+                    (left + 4) + "," + (top - 17) + " " +
+                    (left + 4) + "," + top + " " +
+                    right + "," + top + " " +
+                    right + "," + bottom + " " +
+                    left + "," + bottom + " " +
+                    left + "," + (top - 21)
+                $bubble.setAttribute('points', points)
+            }
+
+            if (data.startsWith("http")) {
+                $img.setAttribute('href', data);
+                i.src = data;
+            }
+            else {
+                $img.setAttribute('href', "data:image/png;base64," + data);
+                i.src = "data:image/png;base64," + data;
+            }
+        }
+
+        RED.events.on("editor:save", redraw)
+
+        RED.comms.subscribe('save-photo', function (event, data) {
+            if (data.hasOwnProperty("data")) {
+                latestImages[data.id] = data.data
+                const node = RED.nodes.node(data.id)
+                if (node) {
+                    render(data.id, data.data, node)
+
+                    // Auto-download if enabled
+                    if (node.autoSave) {
+                        downloadImage(data.data, node.filename);
+                    }
+                }
+            }
+            else {
+                remove(data.id);
+            }
+        })
+    })();
+    </script>
+
+    <script type="text/html" data-template-name="save-photo">
+        <div class="form-row">
+            <label for="node-input-topicType"><i class="fa fa-video-camera"></i> Image Type</label>
+            <select id="node-input-topicType" style="width:70%">
+                <option value="raw">Raw (uncompressed)</option>
+                <option value="compressed">Compressed (full rate)</option>
+                <option value="compressed_2hz">Compressed (2 fps)</option>
+            </select>
+        </div>
+        <div class="form-row">
+            <label for="node-input-topicName"><i class="fa fa-tag"></i> Topic</label>
+            <input type="text" id="node-input-topicName" readonly style="width:70%; background-color: #f0f0f0;">
+        </div>
+        <div class="form-row">
+            <label for="node-input-width"><i class="fa fa-arrows-h"></i> Width</label>
+            <input type="number" id="node-input-width">
+        </div>
+        <div class="form-row">
+            <label for="node-input-filename"><i class="fa fa-file"></i> Filename</label>
+            <input type="text" id="node-input-filename" placeholder="dexi_photo">
+        </div>
+        <div class="form-row">
+            <label>&nbsp;</label>
+            <input type="checkbox" id="node-input-autoSave" style="display:inline-block; width:auto; vertical-align:top;">
+            <label for="node-input-autoSave" style="width:70%;"> Auto-save images</label>
+        </div>
+        <div class="form-row">
+            <label>&nbsp;</label>
+            <input type="checkbox" id="node-input-showPreview" style="display:inline-block; width:auto; vertical-align:top;">
+            <label for="node-input-showPreview" style="width:70%;"> Show image preview</label>
+        </div>
+        <div class="form-row">
+            <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+            <input type="text" id="node-input-name" placeholder="Name">
+        </div>
+    </script>
+
+    <script type="text/html" data-help-name="save-photo">
+        <p>Save photo node that subscribes to camera topics and saves JPG images directly to your computer via browser downloads.</p>
+        <p><strong>Image Types:</strong>
+        <ul>
+            <li><strong>Raw:</strong> Uncompressed images from /cam0/image_raw (higher bandwidth)</li>
+            <li><strong>Compressed:</strong> JPEG compressed images from /cam0/image_raw/compressed (recommended)</li>
+            <li><strong>Compressed (2 fps):</strong> Throttled JPEG images at 2fps from /cam0/image_raw/compressed_2hz</li>
+        </ul>
+        </p>
+        <p><strong>Auto-save:</strong> When enabled, images are automatically downloaded when received.</p>
+        <p><strong>Manual save:</strong> When auto-save is disabled, click the node button or the download icon on the image to save.</p>
+        <p><strong>Note:</strong> All images are saved as JPG format with timestamp in filename.</p>
+    </script>

--- a/src/save-photo.js
+++ b/src/save-photo.js
@@ -1,0 +1,154 @@
+module.exports = function (RED) {
+    var ROSLIB = require('roslib');
+
+    function SavePhotoNode(config) {
+        RED.nodes.createNode(this, config);
+        var node = this;
+
+        node.server = RED.nodes.getNode(config.server);
+        node.topicName = config.topicName || '/cam0/image_raw/compressed';
+        node.topicType = config.topicType || 'compressed';
+        node.filename = config.filename || 'dexi_photo';
+        node.autoSave = config.autoSave || false;
+        node.showPreview = config.showPreview !== false; // default true
+
+        if (!node.server || !node.server.ros) {
+            node.status({fill: "red", shape: "dot", text: "no connection"});
+            return;
+        }
+
+        function sendImageToClient(imageData) {
+            if (!node.showPreview && !node.autoSave) return;
+
+            var d = { id: node.id };
+            if (imageData !== null) {
+                // Handle different image data formats
+                if (Buffer.isBuffer(imageData)) {
+                    imageData = imageData.toString("base64");
+                }
+                d.data = imageData;
+            }
+            try {
+                RED.comms.publish("save-photo", d);
+                node.status({fill: "green", shape: "dot", text: "image received"});
+            }
+            catch(e) {
+                node.error("Invalid image data", e);
+                node.status({fill: "red", shape: "dot", text: "invalid data"});
+            }
+        }
+
+        function processImageMessage(data) {
+            try {
+                let imageData;
+
+                if (node.topicType === 'compressed') {
+                    // Handle sensor_msgs/CompressedImage
+                    if (data.data && data.format) {
+                        // CompressedImage message has data as base64 or buffer
+                        if (Buffer.isBuffer(data.data)) {
+                            imageData = data.data.toString("base64");
+                        } else if (Array.isArray(data.data)) {
+                            imageData = Buffer.from(data.data).toString("base64");
+                        } else {
+                            imageData = data.data;
+                        }
+                        sendImageToClient(imageData);
+                    }
+                } else {
+                    // Handle sensor_msgs/Image (raw)
+                    if (data.encoding && data.width && data.height && data.data) {
+                        // For raw images, we need to convert to base64
+                        // This is more complex and may require image processing
+                        let buffer;
+                        if (Buffer.isBuffer(data.data)) {
+                            buffer = data.data;
+                        } else if (Array.isArray(data.data)) {
+                            buffer = Buffer.from(data.data);
+                        } else {
+                            node.warn('Unsupported raw image data format');
+                            return;
+                        }
+
+                        // For now, pass through raw data - in practice you'd want to
+                        // convert to JPEG using a library like sharp or jimp
+                        sendImageToClient(buffer.toString("base64"));
+                    }
+                }
+
+                // Send message through output
+                node.send({
+                    payload: {
+                        topic: node.topicName,
+                        timestamp: new Date().toISOString(),
+                        imageReceived: true
+                    }
+                });
+
+            } catch (err) {
+                node.error(`Error processing image: ${err.message}`);
+                node.status({fill: "red", shape: "dot", text: "processing error"});
+            }
+        }
+
+        // if topic has not been advertised yet, keep trying again
+        function topicQuery(topic) {
+            node.server.ros.getTopicType(topic.name, (type) => {
+                if (!type) {
+                    setTimeout(() => { topicQuery(topic) }, 1000);
+                } else {
+                    node.log(`Subscribed to ${topic.name} with message type: ${type}`);
+                    topic.subscribe(function (data) {
+                        processImageMessage(data);
+                    });
+                }
+            });
+        }
+
+        node.server.on('ros connected', () => {
+            // Determine message type based on topic type
+            let messageType;
+            if (node.topicType === 'compressed' || node.topicType === 'compressed_2hz') {
+                messageType = 'sensor_msgs/CompressedImage';
+            } else {
+                messageType = 'sensor_msgs/Image';
+            }
+
+            node.topic = new ROSLIB.Topic({
+                ros: node.server.ros,
+                name: node.topicName,
+                messageType: messageType
+            });
+
+            topicQuery(node.topic);
+            node.status({fill: "green", shape: "dot", text: "connected"});
+        });
+
+        node.server.on('ros error', () => {
+            node.status({fill: "red", shape: "dot", text: "connection error"});
+        });
+
+        // Handle manual save trigger
+        node.on("input", function (msg) {
+            if (msg.payload === "save") {
+                // Trigger a save of the latest image
+                node.send({
+                    payload: {
+                        action: "save_requested",
+                        timestamp: new Date().toISOString()
+                    }
+                });
+            }
+        });
+
+        node.on("close", function () {
+            if (node.topic && !node.server.closing) {
+                node.topic.unsubscribe();
+            }
+            // Clear the preview
+            RED.comms.publish("save-photo", { id: node.id });
+        });
+    }
+
+    RED.nodes.registerType("save-photo", SavePhotoNode);
+};

--- a/src/servo.html
+++ b/src/servo.html
@@ -1,0 +1,45 @@
+<script type="text/javascript">
+    RED.nodes.registerType('servo', {
+        category: 'DEXI',
+        color: '#a6bbcf',
+        defaults: {
+            name: {value: "servo"},
+            servoId: {value: "0"},
+            angle: {value: "90"}
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: "file.svg",
+        paletteLabel: "servo",
+        label: function() {
+            return this.name || "servo"
+        }
+    })
+</script>
+
+<script type="text/html" data-template-name="servo">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="servo">
+    </div>
+    <div class="form-row">
+        <label for="node-input-servoId"><i class="icon-tag"></i> Servo ID</label>
+        <select id="node-input-servoId">
+            <option value="0">0</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-angle"><i class="icon-tag"></i> Angle (0-180)</label>
+        <input type="number" id="node-input-angle" min="0" max="180" placeholder="90">
+    </div>
+</script>
+
+<script type="text/html" data-help-name="servo">
+    <p>Control servo motor position</p>
+    <p>Configure the servo ID (0-4) and angle (0-180 degrees)</p>
+    <p>The node will publish to the ROS2 servo control service</p>
+</script>

--- a/src/servo.js
+++ b/src/servo.js
@@ -1,0 +1,42 @@
+module.exports = function(RED) {
+    function ServoNode(config) {
+        RED.nodes.createNode(this, config);
+        var node = this;
+        node.name = config.name;
+        node.servoId = parseInt(config.servoId);
+        node.angle = parseInt(config.angle);
+
+        node.on('input', function(msg) {
+            var servoId = node.servoId;
+            var angle = node.angle;
+
+            // Check if angle was passed as a simple number (e.g., from a slider)
+            // Only accept numbers in valid servo range (0-180)
+            if (typeof msg.payload === 'number' && msg.payload >= 0 && msg.payload <= 180) {
+                angle = parseInt(msg.payload);
+            }
+            // Check if servo parameters were passed as an object
+            else if (typeof msg.payload === 'object') {
+                if (typeof msg.payload.servoId !== 'undefined') {
+                    servoId = parseInt(msg.payload.servoId);
+                }
+                if (typeof msg.payload.angle !== 'undefined') {
+                    angle = parseInt(msg.payload.angle);
+                }
+            }
+            // Otherwise use configured values (handles inject timestamps, etc.)
+
+            msg.payload = {
+                "serviceName": "/dexi/servo_control",
+                "serviceType": "dexi_interfaces/srv/ServoControl",
+                "serviceRequest": {
+                    "pin": servoId,
+                    "angle": angle
+                }
+            }
+            node.send(msg);
+        });
+    }
+
+    RED.nodes.registerType("servo", ServoNode);
+}

--- a/src/write-gpio.html
+++ b/src/write-gpio.html
@@ -3,8 +3,10 @@
         category: 'DEXI',
         color: '#fef5ff',
         defaults: {
+            name: {value: ""},
+            boardtype: {value: 'dexi5', required: true},
             pinnumber: {value: 21, required: true},
-            pinstate: {value: false, required: true},
+            pinstate: {value: 'true', required: true},
             stampheader: {
                 value: false
             }
@@ -15,20 +17,72 @@
         paletteLabel: 'write gpio',
         icon: "icon.png",
         label: function() {
-            return this.topicname || "write gpio";
+            return this.name || "write gpio";
+        },
+        oneditprepare: function() {
+            var node = this;
+
+            // Pin configurations for different boards
+            var pinConfigs = {
+                dexi5: [16, 17, 20, 21, 22, 23, 24],
+                computekit: [0, 1, 2, 14, 15]
+            };
+
+            // Function to update pin dropdown based on board type
+            function updatePinOptions(boardType) {
+                var pinSelect = $('#node-input-pinnumber');
+                var currentPin = node.pinnumber;
+                var pins = pinConfigs[boardType] || pinConfigs.dexi5;
+
+                // Clear existing options
+                pinSelect.empty();
+
+                // Add new options
+                pins.forEach(function(pin) {
+                    pinSelect.append($('<option>', {
+                        value: pin,
+                        text: pin
+                    }));
+                });
+
+                // Try to restore previous selection if valid for this board
+                if (pins.indexOf(parseInt(currentPin)) !== -1) {
+                    pinSelect.val(currentPin);
+                } else {
+                    // Otherwise select the first pin
+                    pinSelect.val(pins[0]);
+                }
+            }
+
+            // Initialize pin options based on current board type
+            updatePinOptions(node.boardtype || 'dexi5');
+
+            // Update pins when board type changes
+            $('#node-input-boardtype').on('change', function() {
+                updatePinOptions($(this).val());
+            });
         }
     })
 </script>
 
 <script type="text/html" data-template-name="write-gpio">
     <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-boardtype">Board Type</label>
+        <select id="node-input-boardtype">
+            <option value="dexi5">DEXI 5</option>
+            <option value="computekit">DEXI Compute Kit</option>
+        </select>
+    </div>
+
+    <div class="form-row">
         <label for="node-input-pinnumber">Pin Number</label>
         <select id="node-input-pinnumber">
-            <option value="21">21</option>
-            <option value="21">22</option>
-            <option value="21">23</option>
-            <option value="21">24</option>
-            <option value="21">25</option>
+            <!-- Options populated dynamically based on board type -->
         </select>
     </div>
 

--- a/src/write-gpio.js
+++ b/src/write-gpio.js
@@ -4,10 +4,10 @@ module.exports = function(RED) {
       var node = this
       node.on('input', function(msg) {
           msg.payload = {
-              "serviceName": `/dexi/gpio_writer_service/write_gpio_${config.pinnumber}`,
+              "serviceName": `/dexi/gpio_writer_service/write_gpio`,
               "serviceType": "dexi_interfaces/srv/GPIOSend",
               "serviceRequest": {
-                "pin": 21,
+                "pin": parseInt(config.pinnumber),
                 "state": config.pinstate === 'true'
               }
           }


### PR DESCRIPTION
## Summary
- Add save-photo node for camera image capture with browser download support
- Add servo control node for ROS2 servo management
- Improve write-gpio node with name field and persistent pin selection
- Add comprehensive Compute Kit example flows (servo control, GPIO, open collector/laser)
- Update development setup documentation

## Key Features

### save-photo Node
- Accepts image data from ROS2 topics and saves JPG images via browser downloads
- Supports auto-save mode and manual download options
- Shows image preview in Node-RED editor
- Handles multiple image formats (base64, ROS CompressedImage, raw Image messages)

### servo Node
- Control ROS2 servos with configurable servo ID and angle
- Supports angles from 0-180 degrees
- Integration with Compute Kit hardware

### write-gpio Improvements
- Added name field for better node identification
- Persistent pin selection in editor
- Support for Compute Kit and Stamp header GPIO options

### Example Flows
- Compute Kit Servo Control: Demonstrates servo control with buttons and sliders
- Compute Kit GPIO: LED control example using GPIO pins
- Compute Kit Open Collector: Laser pulse example with timing control

## Test Plan
- [ ] Test save-photo node with ROS2 camera topics
- [ ] Verify servo control with Compute Kit hardware
- [ ] Test GPIO write operations
- [ ] Validate example flows load and execute correctly
- [ ] Confirm browser download functionality for images