### PR TITLE
Add circle flight node

### DIFF
--- a/flows/circle_flight_test.json
+++ b/flows/circle_flight_test.json
@@ -1,0 +1,309 @@
+[
+    {
+        "id": "circle_test_tab",
+        "type": "tab",
+        "label": "Circle Flight Test",
+        "disabled": false,
+        "info": "Test flow for circle flight path with full sequence: arm, takeoff, offboard mode, circle, land, disarm"
+    },
+    {
+        "id": "ros2_websocket",
+        "type": "ros2-websocket-server",
+        "url": "ws://172.17.0.2:9090",
+        "name": "ROS2 WebSocket"
+    },
+    {
+        "id": "inject_start",
+        "type": "inject",
+        "z": "circle_test_tab",
+        "name": "START Circle Test",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "",
+        "payloadType": "date",
+        "x": 150,
+        "y": 100,
+        "wires": [
+            [
+                "delay_start"
+            ]
+        ]
+    },
+    {
+        "id": "delay_start",
+        "type": "delay",
+        "z": "circle_test_tab",
+        "name": "Wait 1s",
+        "pauseType": "delay",
+        "timeout": "1",
+        "timeoutUnits": "seconds",
+        "rate": "1",
+        "nbRateUnits": "1",
+        "rateUnits": "second",
+        "randomFirst": "1",
+        "randomLast": "5",
+        "randomUnits": "seconds",
+        "drop": false,
+        "allowrate": false,
+        "outputs": 1,
+        "x": 340,
+        "y": 100,
+        "wires": [
+            [
+                "start_offboard"
+            ]
+        ]
+    },
+    {
+        "id": "start_offboard",
+        "type": "offboard",
+        "z": "circle_test_tab",
+        "name": "Start Offboard Heartbeat",
+        "server": "ros2_websocket",
+        "topic": "offboard_manager",
+        "x": 540,
+        "y": 100,
+        "wires": [
+            [
+                "delay_after_offboard"
+            ]
+        ]
+    },
+    {
+        "id": "delay_after_offboard",
+        "type": "delay",
+        "z": "circle_test_tab",
+        "name": "Wait 2s",
+        "pauseType": "delay",
+        "timeout": "2",
+        "timeoutUnits": "seconds",
+        "rate": "1",
+        "nbRateUnits": "1",
+        "rateUnits": "second",
+        "randomFirst": "1",
+        "randomLast": "5",
+        "randomUnits": "seconds",
+        "drop": false,
+        "allowrate": false,
+        "outputs": 1,
+        "x": 760,
+        "y": 100,
+        "wires": [
+            [
+                "arm_node"
+            ]
+        ]
+    },
+    {
+        "id": "arm_node",
+        "type": "arm",
+        "z": "circle_test_tab",
+        "name": "Arm",
+        "server": "ros2_websocket",
+        "topic": "offboard_manager",
+        "x": 930,
+        "y": 100,
+        "wires": [
+            [
+                "delay_after_arm"
+            ]
+        ]
+    },
+    {
+        "id": "delay_after_arm",
+        "type": "delay",
+        "z": "circle_test_tab",
+        "name": "Wait 2s",
+        "pauseType": "delay",
+        "timeout": "2",
+        "timeoutUnits": "seconds",
+        "rate": "1",
+        "nbRateUnits": "1",
+        "rateUnits": "second",
+        "randomFirst": "1",
+        "randomLast": "5",
+        "randomUnits": "seconds",
+        "drop": false,
+        "allowrate": false,
+        "outputs": 1,
+        "x": 1100,
+        "y": 100,
+        "wires": [
+            [
+                "takeoff_node"
+            ]
+        ]
+    },
+    {
+        "id": "takeoff_node",
+        "type": "takeoff",
+        "z": "circle_test_tab",
+        "name": "Takeoff 3m",
+        "altitude": "3.0",
+        "server": "ros2_websocket",
+        "topic": "offboard_manager",
+        "x": 150,
+        "y": 200,
+        "wires": [
+            [
+                "delay_after_takeoff"
+            ]
+        ]
+    },
+    {
+        "id": "delay_after_takeoff",
+        "type": "delay",
+        "z": "circle_test_tab",
+        "name": "Wait 5s (stabilize)",
+        "pauseType": "delay",
+        "timeout": "5",
+        "timeoutUnits": "seconds",
+        "rate": "1",
+        "nbRateUnits": "1",
+        "rateUnits": "second",
+        "randomFirst": "1",
+        "randomLast": "5",
+        "randomUnits": "seconds",
+        "drop": false,
+        "allowrate": false,
+        "outputs": 1,
+        "x": 360,
+        "y": 200,
+        "wires": [
+            [
+                "circle_node"
+            ]
+        ]
+    },
+    {
+        "id": "circle_node",
+        "type": "circle",
+        "z": "circle_test_tab",
+        "name": "Fly Circle 2m radius",
+        "radius": "2.0",
+        "server": "ros2_websocket",
+        "topic": "offboard_manager",
+        "x": 590,
+        "y": 200,
+        "wires": [
+            [
+                "delay_after_circle"
+            ]
+        ]
+    },
+    {
+        "id": "delay_after_circle",
+        "type": "delay",
+        "z": "circle_test_tab",
+        "name": "Wait 2s",
+        "pauseType": "delay",
+        "timeout": "2",
+        "timeoutUnits": "seconds",
+        "rate": "1",
+        "nbRateUnits": "1",
+        "rateUnits": "second",
+        "randomFirst": "1",
+        "randomLast": "5",
+        "randomUnits": "seconds",
+        "drop": false,
+        "allowrate": false,
+        "outputs": 1,
+        "x": 820,
+        "y": 200,
+        "wires": [
+            [
+                "land_node"
+            ]
+        ]
+    },
+    {
+        "id": "land_node",
+        "type": "land",
+        "z": "circle_test_tab",
+        "name": "Land",
+        "server": "ros2_websocket",
+        "topic": "offboard_manager",
+        "x": 990,
+        "y": 200,
+        "wires": [
+            [
+                "delay_after_land"
+            ]
+        ]
+    },
+    {
+        "id": "delay_after_land",
+        "type": "delay",
+        "z": "circle_test_tab",
+        "name": "Wait 5s",
+        "pauseType": "delay",
+        "timeout": "5",
+        "timeoutUnits": "seconds",
+        "rate": "1",
+        "nbRateUnits": "1",
+        "rateUnits": "second",
+        "randomFirst": "1",
+        "randomLast": "5",
+        "randomUnits": "seconds",
+        "drop": false,
+        "allowrate": false,
+        "outputs": 1,
+        "x": 1150,
+        "y": 200,
+        "wires": [
+            [
+                "disarm_node"
+            ]
+        ]
+    },
+    {
+        "id": "disarm_node",
+        "type": "disarm",
+        "z": "circle_test_tab",
+        "name": "Disarm",
+        "server": "ros2_websocket",
+        "topic": "offboard_manager",
+        "x": 150,
+        "y": 300,
+        "wires": [
+            [
+                "debug_complete"
+            ]
+        ]
+    },
+    {
+        "id": "debug_complete",
+        "type": "debug",
+        "z": "circle_test_tab",
+        "name": "Test Complete",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 340,
+        "y": 300,
+        "wires": []
+    },
+    {
+        "id": "comment_header",
+        "type": "comment",
+        "z": "circle_test_tab",
+        "name": "Circle Flight Test Sequence",
+        "info": "This flow tests the new circle flight path with the following sequence:\n1. Start offboard heartbeat (1s wait)\n2. Arm the drone (2s wait)\n3. Takeoff to 3m altitude (5s stabilize)\n4. Execute circle with 2m radius\n5. Land (5s wait)\n6. Disarm\n\nTo test:\n1. Make sure ROS2 and PX4 are running\n2. Click the inject button to start the sequence\n3. Watch the drone execute the full flight path\n\nTo modify:\n- Change radius in the circle node\n- Adjust takeoff altitude in the takeoff node\n- Modify wait times in delay nodes as needed",
+        "x": 180,
+        "y": 40,
+        "wires": []
+    }
+]

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
       "ros2-service-call": "src/ros2-service-call.js",
       "write-gpio": "src/write-gpio.js",
       "image-preview": "src/image-preview.js",
-      "save-photo": "src/save-photo.js"
+      "save-photo": "src/save-photo.js",
+      "circle": "src/circle.js"
     }
   },
   "keywords": [

--- a/src/circle.html
+++ b/src/circle.html
@@ -1,0 +1,29 @@
+<script type="text/javascript">
+    RED.nodes.registerType('circle',{
+        category: 'DEXI',
+        color: '#a6bbcf',
+        defaults: {
+            name: {value: ""},
+            radius: {value: 2.0}
+        },
+        inputs: 1,
+        outputs: 1,
+        icon: "font-awesome/fa-circle-o",
+        paletteLabel: "fly circle",
+        label: function() {
+            return (this.name ? this.name + " - " : "") + "circle: " + this.radius + "m radius";
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="circle">
+    <div class="form-row">
+        <label for="node-input-radius"><i class="fa fa-circle-o"></i> Radius (m)</label>
+        <input type="text" id="node-input-radius" placeholder="2.0">
+    </div>
+</script>
+
+<script type="text/html" data-help-name="circle">
+    <p>Fly in a circle at the current altitude with the specified radius.</p>
+    <p>The drone will complete one full 360-degree circle and return to the starting position.</p>
+</script>

--- a/src/circle.js
+++ b/src/circle.js
@@ -1,0 +1,18 @@
+module.exports = function(RED) {
+    function FlyCircleNode(config) {
+        RED.nodes.createNode(this, config);
+        var node = this;
+
+        let radius = parseFloat(config.radius) || 2.0; // Default to 2.0m if undefined
+
+        node.on('input', function(msg) {
+            // Adheres to offboardnavcommand message format from dexi_interfaces
+            msg.payload = {
+                "command": "circle",
+                "distance_or_degrees": radius
+            }
+            node.send(msg)
+        })
+    }
+    RED.nodes.registerType("circle", FlyCircleNode);
+}


### PR DESCRIPTION
## Summary
- Add new circle flight node that allows the drone to fly in a circular pattern at current altitude
- Node accepts a configurable radius parameter (default 2.0m)
- Includes test flow demonstrating full flight sequence: arm → takeoff → offboard mode → circle → land → disarm

## Changes
- Added `src/circle.js` and `src/circle.html` for the new node
- Updated `package.json` to register the circle node
- Added `flows/circle_flight_test.json` test flow with complete flight sequence
- Merged latest main branch LED effect updates

## Test plan
- [ ] Verify circle node appears in DEXI category in Node-RED palette
- [ ] Test with ROS2 and PX4 running
- [ ] Execute test flow and verify drone completes circle pattern
- [ ] Verify radius parameter can be configured
- [ ] Test full sequence: offboard → arm → takeoff → circle → land → disarm