### PR TITLE
Add ROS2_WEBSOCKET_URL environment variable support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM nodered/node-red:latest-minimal
 
+# Set default websocket URL for physical hardware (can be overridden)
+ENV ROS2_WEBSOCKET_URL=ws://192.168.4.1:9090
+
 RUN npm i @droneblocks/node-red-dexi
 
 # For displaying led on dashboard

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # Node RED flow development for DEXI
- 
+
 You want to make sure you don't lose any of your flow development. Make sure to map the host "flows" directory to the container directory as shown below. This will store the flow on your host machine if/when the container is destroyed.
 
+## Running on Physical Hardware (default)
+
 ```docker run -it -p 1880:1880 -v ${PWD}/flows:/data --name dexi-node-red droneblocks/dexi-node-red:latest```
+
+## Running in Simulation Environment
+
+For simulation environments, override the websocket URL:
+
+```docker run -it -p 1880:1880 -e ROS2_WEBSOCKET_URL=ws://ros2-dev:9090 -v ${PWD}/flows:/data --name dexi-node-red droneblocks/dexi-node-red:latest```
+
+The default websocket URL is `ws://192.168.4.1:9090` (physical hardware). Set the `ROS2_WEBSOCKET_URL` environment variable to customize for different environments.
 
 # Node RED custom node development for DEXI
 

--- a/flows/flows.json
+++ b/flows/flows.json
@@ -122,7 +122,7 @@
     {
         "id": "27129f80a96ce509",
         "type": "ros2-websocket-server",
-        "url": "ws://192.168.4.1:9090"
+        "url": "${ROS2_WEBSOCKET_URL}"
     },
     {
         "id": "5788a4cce510d440",


### PR DESCRIPTION
## Summary
- Makes websocket server URL configurable via environment variable
- Default: `ws://192.168.4.1:9090` (physical hardware)
- Can be overridden for simulation: `ROS2_WEBSOCKET_URL=ws://ros2-dev:9090`

## Changes
- Dockerfile: Added `ENV ROS2_WEBSOCKET_URL` default
- flows/flows.json: Changed hardcoded URL to `${ROS2_WEBSOCKET_URL}`
- README: Added usage documentation

## Test plan
- [ ] Run container with default (physical hardware mode)
- [ ] Run container with `-e ROS2_WEBSOCKET_URL=ws://ros2-dev:9090` (simulation mode)